### PR TITLE
Test fix for successful build

### DIFF
--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -107,9 +107,9 @@ BOOST_AUTO_TEST_CASE(sign)
     // All of the above should be OK, and the txTos have valid signatures
     // Check to make sure signature verification fails if we use the wrong ScriptSig:
     for (int i = 0; i < 8; i++) {
-        PrecomputedTransactionData txdata(txTo[i]);
         for (int j = 0; j < 8; j++)
         {
+            PrecomputedTransactionData txdata(txTo[i]);
             CScript sigSave = txTo[i].vin[0].scriptSig;
             txTo[i].vin[0].scriptSig = txTo[j].vin[0].scriptSig;
             bool sigOK = CScriptCheck(txFrom.vout[txTo[i].vin[0].prevout.n], txTo[i], 0, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC, false, &txdata)();


### PR DESCRIPTION
make
Making all in src
make[1]: Entering directory '/home/napoly/git/GlobalBoost-Y/src'
make[2]: Entering directory '/home/napoly/git/GlobalBoost-Y/src'
make[3]: Entering directory '/home/napoly/git/GlobalBoost-Y'
make[3]: Leaving directory '/home/napoly/git/GlobalBoost-Y'
  CXX      libglobalboost_util_a-clientversion.o
  AR       libglobalboost_util.a
  CXXLD    globalboostd
  CXXLD    globalboost-cli
  CXXLD    globalboost-tx
  CXX      test/test_test_globalboost-script_p2sh_tests.o
g++: error: ./test/script_p2sh_tests.cpp: No such file or directory
g++: fatal error: no input files
compilation terminated.
Makefile:9703: recipe for target 'test/test_test_globalboost-script_p2sh_tests.o' failed
make[2]: *** [test/test_test_globalboost-script_p2sh_tests.o] Error 1
make[2]: Leaving directory '/home/napoly/git/GlobalBoost-Y/src'
Makefile:10172: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory '/home/napoly/git/GlobalBoost-Y/src'
Makefile:774: recipe for target 'all-recursive' failed
make: *** [all-recursive] Error 1